### PR TITLE
Issue3 fix

### DIFF
--- a/R/FamiliasPosterior.R
+++ b/R/FamiliasPosterior.R
@@ -1,5 +1,5 @@
 FamiliasPosterior <- function (pedigrees, loci, datamatrix, prior, ref = 1, kinship = 0, 
-    simplifyMutations = FALSE) 
+                               simplifyMutations = FALSE) 
 {
     if (missing(pedigrees) || length(pedigrees) < 1) 
         stop("The pedigrees parameter must be an object of type 'pedigree' or 'FamiliasPedigree', or a list of such.")
@@ -23,38 +23,65 @@ FamiliasPosterior <- function (pedigrees, loci, datamatrix, prior, ref = 1, kins
         stop("The prior must consist of non-negative numbers summing to 1.")
     if (missing(datamatrix)) 
         stop("The datamatrix must be supplied.")
-    persons <- rownames(datamatrix)
-    if (length(persons) < 1) 
+    if (length(rownames(datamatrix)) < 1) 
         stop("The row names of the datamatrix must contain the names of the persons you have data for.")
-    npers <- length(persons)
-    indextable <- matrix(0, npers, npeds)
-    firstped <- pedigrees[[1]]
-    for (i in 1:npeds) for (j in 1:npers) {
-        indextable[j, i] <- match(persons[j], pedigrees[[i]]$id, 
-            nomatch = 0)
-        if (indextable[j, i] == 0) 
-            stop(paste("Error: Person ", persons[j], "of the data matrix does not occur in pedigree", 
-                i))
-        if (i > 1) {
-            if (pedigrees[[i]]$sex[indextable[j, i]] != firstped$sex[indextable[j, 
-                1]]) 
+    
+    # ensure untyped persons in the pedigree are present in the datamatrix if kinship>0
+    # because pruning those persons would affect the likelihood if mutations are possible
+    npersDatamatrixOriginal <- nrow(datamatrix)
+    if (kinship>0){
+        pedigreePersons <- unique(unlist(lapply(pedigrees, function(x) x$id)))
+        
+        personsToAdd <- pedigreePersons[!pedigreePersons %in% rownames(datamatrix)]
+        
+        datamatrixBlanks <- matrix(NA, nrow = length(personsToAdd),
+                                   ncol = ncol(datamatrix),
+                                   dimnames = list(personsToAdd))
+        
+        datamatrix <- rbind(datamatrix, datamatrixBlanks)
+    }
+    
+    personsDatamatrix <- rownames(datamatrix)
+    
+    npersDatamatrix <- length(personsDatamatrix)
+    pedPersonIndicesByDmPersonIndex <- matrix(0, npersDatamatrix, npeds)
+    
+    for (i in 1:npeds) for (j in 1:npersDatamatrix) {
+        pedPersonIndicesByDmPersonIndex[j, i] <- match(personsDatamatrix[j], pedigrees[[i]]$id, 
+                                                       nomatch = 0)
+        if (pedPersonIndicesByDmPersonIndex[j, i] == 0 && 
+            (!all(is.na(datamatrix[j,])))) 
+        {
+            stop(paste("Error: Person ", personsDatamatrix[j], "of the data matrix is typed and does not occur in pedigree", 
+                       i))
+        }
+        
+        if ((i > 1) && (j<=npersDatamatrixOriginal)) {
+            firstObseredInPed <- 1
+            while(pedPersonIndicesByDmPersonIndex[j,firstObseredInPed]==0) firstObseredInPed <- firstObseredInPed + 1
+            
+            if (pedigrees[[i]]$sex[pedPersonIndicesByDmPersonIndex[j, i]] != 
+                pedigrees[[firstObseredInPed]]$sex[pedPersonIndicesByDmPersonIndex[j, firstObseredInPed]]) 
                 stop("Persons common to all pedigrees must have the same sex in all pedigrees!")
         }
     }
     .C("NewFamilias")
-    for (j in 1:npers) {
-        result <- .C("AddPerson", as.integer(!(firstped$sex[indextable[j, 
-            1]] == "female")), as.integer(-1), as.integer(FALSE), 
-            index = integer(1), error = integer(1))
+    for (j in 1:npersDatamatrix) {
+        iPed <- 1
+        while(pedPersonIndicesByDmPersonIndex[j,iPed]==0) iPed <- iPed + 1
+        
+        result <- .C("AddPerson", as.integer(!(pedigrees[[iPed]]$sex[pedPersonIndicesByDmPersonIndex[j, 
+                                                                                                     iPed]] == "female")), as.integer(-1), as.integer(FALSE), 
+                     index = integer(1), error = integer(1))
         if (result$error > 0) 
             stop("ERROR: Problems with common persons in pedigree.")
     }
     for (i in pedigrees) {
-        nPersons <- length(i$sex)
-        neworder <- rep(0, nPersons)
+        nPersons_ped <- length(i$sex)
+        neworder <- rep(0, nPersons_ped)
         nExMales <- nExFemales <- 0
-        for (j in 1:nPersons) {
-            mm <- match(i$id[j], persons, nomatch = 0)
+        for (j in 1:nPersons_ped) {
+            mm <- match(i$id[j], personsDatamatrix, nomatch = 0)
             if (mm > 0) 
                 neworder[j] <- mm
             else if (i$sex[j] == "female") {
@@ -66,40 +93,40 @@ FamiliasPosterior <- function (pedigrees, loci, datamatrix, prior, ref = 1, kins
                 neworder[j] <- nExMales
             }
         }
-        for (j in 1:nPersons) {
-            if (!(i$id[j] %in% persons)) {
+        for (j in 1:nPersons_ped) {
+            if (!(i$id[j] %in% personsDatamatrix)) {
                 if (i$sex[j] == "female") 
-                  neworder[j] <- neworder[j] + npers
-                else neworder[j] <- neworder[j] + npers + nExFemales
+                    neworder[j] <- neworder[j] + npersDatamatrix
+                else neworder[j] <- neworder[j] + npersDatamatrix + nExFemales
             }
         }
         result <- .C("AddPedigree", as.integer(nExFemales), as.integer(nExMales), 
-            index = integer(1), error = integer(1))
+                     index = integer(1), error = integer(1))
         if (result$error > 0) 
             stop("ERROR: Wrong input in pedigrees.")
         index <- result$index + 1
-        for (j in 1:nPersons) {
+        for (j in 1:nPersons_ped) {
             if (i$findex[j] > 0) {
                 result <- .C("AddRelation", as.integer(neworder[i$findex[j]] - 
-                  1), as.integer(neworder[j] - 1), as.integer(index - 
-                  1), error = integer(1))
+                                                           1), as.integer(neworder[j] - 1), as.integer(index - 
+                                                                                                           1), error = integer(1))
                 if (result$error == 1) 
-                  stop("ERROR: Wrong input.")
+                    stop("ERROR: Wrong input.")
                 else if (result$error == 2) 
-                  stop("ERROR: Illegal relation based on Year-of-birth or is-Child data.")
+                    stop("ERROR: Illegal relation based on Year-of-birth or is-Child data.")
                 else if (result$error == 3) 
-                  stop("ERROR: Cycle in the pedigree or duplicate parent.")
+                    stop("ERROR: Cycle in the pedigree or duplicate parent.")
             }
             if (i$mindex[j] > 0) {
                 result <- .C("AddRelation", as.integer(neworder[i$mindex[j]] - 
-                  1), as.integer(neworder[j] - 1), as.integer(index - 
-                  1), error = integer(1))
+                                                           1), as.integer(neworder[j] - 1), as.integer(index - 
+                                                                                                           1), error = integer(1))
                 if (result$error == 1) 
-                  stop("ERROR: Wrong input.")
+                    stop("ERROR: Wrong input.")
                 else if (result$error == 2) 
-                  stop("ERROR: Illegal relation based on Year-of-birth or is-Child data.")
+                    stop("ERROR: Illegal relation based on Year-of-birth or is-Child data.")
                 else if (result$error == 3) 
-                  stop("ERROR: Cycle in the pedigree or duplicate parent.")
+                    stop("ERROR: Cycle in the pedigree or duplicate parent.")
             }
         }
     }
@@ -121,79 +148,79 @@ FamiliasPosterior <- function (pedigrees, loci, datamatrix, prior, ref = 1, kins
     for (i in loci) {
         if (any(i$alleles <= 0)) 
             stop(paste("ERROR: Problems with allele frequencies in locus", 
-                i$locusname))
+                       i$locusname))
         if (round(sum(i$alleles), 6) != 1) 
             stop(paste("ERROR: Allele frequencies must sum to 1 in locus", 
-                i$locusname))
+                       i$locusname))
         nAlleles <- length(i$alleles)
         if (!is.matrix(i$femaleMutationMatrix) | dim(i$femaleMutationMatrix)[1] != 
             nAlleles | dim(i$femaleMutationMatrix)[2] != nAlleles) 
             stop(paste("The female mutation matrix must be of a dimension corresponding to the vector of frequencies in locus", 
-                i$locusname))
+                       i$locusname))
         if (any(as.vector(i$femaleMutationMatrix) < 0)) 
             stop(paste("The female mutation matrix cannot have negative entries in locus", 
-                i$locusname))
+                       i$locusname))
         if (any(round(apply(i$femaleMutationMatrix, 1, sum), 
-            6) != 1)) 
+                      6) != 1)) 
             stop(paste("The rows in the female mutation matrix must sum to 1 in locus", 
-                i$locusname))
+                       i$locusname))
         if (!is.matrix(i$maleMutationMatrix) | dim(i$maleMutationMatrix)[1] != 
             nAlleles | dim(i$maleMutationMatrix)[2] != nAlleles) 
             stop(paste("The male mutation matrix must be of a dimension corresponding to the vector of frequencies in locus", 
-                i$locusname))
+                       i$locusname))
         if (any(as.vector(i$maleMutationMatrix) < 0)) 
             stop(paste("The male mutation matrix cannot have negative entries in locus", 
-                i$locusname))
+                       i$locusname))
         if (any(round(apply(i$maleMutationMatrix, 1, sum), 6) != 
-            1)) 
+                1)) 
             stop(paste("The rows in the male mutation matrix must sum to 1 in locus", 
-                i$locusname))
+                       i$locusname))
         lOfArrays <- nAlleles * nAlleles
         simplifyMatrix <- i$simpleMutationMatrices | simplifyMutations
         hasSilentAllele <- (names(i$alleles)[nAlleles] == "silent" | 
-            names(i$alleles)[nAlleles] == "Silent")
+                                names(i$alleles)[nAlleles] == "Silent")
         result <- .C("AddAlleleSystem", as.integer(nAlleles), 
-            as.integer(lOfArrays), as.double(i$femaleMutationMatrix), 
-            as.double(i$maleMutationMatrix), as.integer(simplifyMatrix), 
-            as.integer(nAlleles), as.double(i$alleles), as.integer(hasSilentAllele), 
-            index = integer(1), error = integer(1))
+                     as.integer(lOfArrays), as.double(i$femaleMutationMatrix), 
+                     as.double(i$maleMutationMatrix), as.integer(simplifyMatrix), 
+                     as.integer(nAlleles), as.double(i$alleles), as.integer(hasSilentAllele), 
+                     index = integer(1), error = integer(1))
         if (result$error > 0) 
             stop(paste("ERROR: Problems with input of allele system.", 
-                i$locusname))
+                       i$locusname))
     }
     if (dim(datamatrix)[2] != 2 * nloci) 
         stop("The datamatrix must have two columns for each locus.")
     for (i in 1:nloci) {
-        for (j in 1:npers) {
+        for (j in 1:npersDatamatrix) {
             A1 <- datamatrix[j, 2 * i - 1]
             A2 <- datamatrix[j, 2 * i]
             if (!(is.na(A1) && is.na(A2))) {
                 if (is.na(A1)) 
-                  A1 <- A2
+                    A1 <- A2
                 if (is.na(A2)) 
-                  A2 <- A1
+                    A2 <- A1
                 M1 <- match(A1, names(loci[[i]]$alleles), nomatch = 0)
                 if (M1 == 0) 
-                  stop(paste("Allele", A1, "is not found in locus", 
-                    loci[[i]]$locusname))
+                    stop(paste("Allele", A1, "is not found in locus", 
+                               loci[[i]]$locusname))
                 M2 <- match(A2, names(loci[[i]]$alleles), nomatch = 0)
                 if (M2 == 0) 
-                  stop(paste("Allele", A2, "is not found in locus", 
-                    loci[[i]]$locusname))
+                    stop(paste("Allele", A2, "is not found in locus", 
+                               loci[[i]]$locusname))
                 result <- .C("AddDNAObservation", as.integer(j - 
-                  1), as.integer(i - 1), as.integer(M1 - 1), 
-                  as.integer(M2 - 1), error = integer(1))
+                                                                 1), as.integer(i - 1), as.integer(M1 - 1), 
+                             as.integer(M2 - 1), error = integer(1))
                 if (result$error > 0) 
-                  stop("ERROR: Problems with input of marker data.")
+                    stop("ERROR: Problems with input of marker data.")
             }
         }
     }
     if (kinship < 0) 
         stop("ERROR: Kinship cannot be negative.")
     result <- .C("GetProbabilities", as.double(1), as.integer(-1), 
-        as.double(1), as.double(1), as.integer(TRUE), as.double(kinship), 
-        redundant = integer(npeds), probabilities = double(npeds), 
-        likelihoods = double(nloci * npeds), error = integer(1))
+                 as.double(1), as.double(1), as.integer(TRUE), as.double(kinship), 
+                 redundant = integer(npeds), probabilities = double(npeds), 
+                 likelihoods = double(nloci * npeds), error = integer(1))
     if (result$error == 1) 
         stop("ERROR: Problems computing probabilities.")
     if (result$error == 2) 
@@ -201,16 +228,16 @@ FamiliasPosterior <- function (pedigrees, loci, datamatrix, prior, ref = 1, kins
     pedigreeDuplicated <- as.logical(result$redundant)
     if (any(pedigreeDuplicated)) 
         stop(paste("ERROR: Some of the listed pedigrees were equivalent. Duplicated pedigrees are numbers", 
-            (1:npeds)[pedigreeDuplicated]))
+                   (1:npeds)[pedigreeDuplicated]))
     #prior <- result$probabilities
     likelihoodsPerSystem <- matrix(result$likelihoods, nloci, 
-        npeds)
+                                   npeds)
     likelihoods <- apply(likelihoodsPerSystem, 2, prod)
     posterior <- prior * likelihoods
     posterior <- posterior/sum(posterior)
     LR <- likelihoods/likelihoods[ref]
     LRperMarker <- likelihoodsPerSystem/likelihoodsPerSystem[, 
-        ref]
+                                                             ref]
     .C("NewFamilias")
     names(posterior) <- names(pedigrees)
     names(prior) <- names(pedigrees)
@@ -223,5 +250,5 @@ FamiliasPosterior <- function (pedigrees, loci, datamatrix, prior, ref = 1, kins
     colnames(likelihoodsPerSystem) <- names(pedigrees)
     rownames(likelihoodsPerSystem) <- locusnames
     list(posterior = posterior, prior = prior, LR = LR, LRperMarker = LRperMarker, 
-        likelihoods = likelihoods, likelihoodsPerSystem = likelihoodsPerSystem)
+         likelihoods = likelihoods, likelihoodsPerSystem = likelihoodsPerSystem)
 }

--- a/R/FamiliasPosterior.R
+++ b/R/FamiliasPosterior.R
@@ -1,5 +1,5 @@
 FamiliasPosterior <- function (pedigrees, loci, datamatrix, prior, ref = 1, kinship = 0, 
-                               simplifyMutations = FALSE) 
+    simplifyMutations = FALSE) 
 {
     if (missing(pedigrees) || length(pedigrees) < 1) 
         stop("The pedigrees parameter must be an object of type 'pedigree' or 'FamiliasPedigree', or a list of such.")
@@ -33,10 +33,10 @@ FamiliasPosterior <- function (pedigrees, loci, datamatrix, prior, ref = 1, kins
         pedigreePersons <- unique(unlist(lapply(pedigrees, function(x) x$id)))
         
         personsToAdd <- pedigreePersons[!pedigreePersons %in% rownames(datamatrix)]
-        
+
         datamatrixBlanks <- matrix(NA, nrow = length(personsToAdd),
-                                   ncol = ncol(datamatrix),
-                                   dimnames = list(personsToAdd))
+                                    ncol = ncol(datamatrix),
+                                    dimnames = list(personsToAdd))
         
         datamatrix <- rbind(datamatrix, datamatrixBlanks)
     }
@@ -48,14 +48,14 @@ FamiliasPosterior <- function (pedigrees, loci, datamatrix, prior, ref = 1, kins
     
     for (i in 1:npeds) for (j in 1:npersDatamatrix) {
         pedPersonIndicesByDmPersonIndex[j, i] <- match(personsDatamatrix[j], pedigrees[[i]]$id, 
-                                                       nomatch = 0)
+            nomatch = 0)
         if (pedPersonIndicesByDmPersonIndex[j, i] == 0 && 
             (!all(is.na(datamatrix[j,])))) 
         {
             stop(paste("Error: Person ", personsDatamatrix[j], "of the data matrix is typed and does not occur in pedigree", 
-                       i))
+                i))
         }
-        
+            
         if ((i > 1) && (j<=npersDatamatrixOriginal)) {
             firstObseredInPed <- 1
             while(pedPersonIndicesByDmPersonIndex[j,firstObseredInPed]==0) firstObseredInPed <- firstObseredInPed + 1
@@ -71,16 +71,16 @@ FamiliasPosterior <- function (pedigrees, loci, datamatrix, prior, ref = 1, kins
         while(pedPersonIndicesByDmPersonIndex[j,iPed]==0) iPed <- iPed + 1
         
         result <- .C("AddPerson", as.integer(!(pedigrees[[iPed]]$sex[pedPersonIndicesByDmPersonIndex[j, 
-                                                                                                     iPed]] == "female")), as.integer(-1), as.integer(FALSE), 
-                     index = integer(1), error = integer(1))
+            iPed]] == "female")), as.integer(-1), as.integer(FALSE), 
+            index = integer(1), error = integer(1))
         if (result$error > 0) 
             stop("ERROR: Problems with common persons in pedigree.")
     }
     for (i in pedigrees) {
-        nPersons_ped <- length(i$sex)
-        neworder <- rep(0, nPersons_ped)
+        nPersonsPed <- length(i$sex)
+        neworder <- rep(0, nPersonsPed)
         nExMales <- nExFemales <- 0
-        for (j in 1:nPersons_ped) {
+        for (j in 1:nPersonsPed) {
             mm <- match(i$id[j], personsDatamatrix, nomatch = 0)
             if (mm > 0) 
                 neworder[j] <- mm
@@ -93,40 +93,40 @@ FamiliasPosterior <- function (pedigrees, loci, datamatrix, prior, ref = 1, kins
                 neworder[j] <- nExMales
             }
         }
-        for (j in 1:nPersons_ped) {
+        for (j in 1:nPersonsPed) {
             if (!(i$id[j] %in% personsDatamatrix)) {
                 if (i$sex[j] == "female") 
-                    neworder[j] <- neworder[j] + npersDatamatrix
+                  neworder[j] <- neworder[j] + npersDatamatrix
                 else neworder[j] <- neworder[j] + npersDatamatrix + nExFemales
             }
         }
         result <- .C("AddPedigree", as.integer(nExFemales), as.integer(nExMales), 
-                     index = integer(1), error = integer(1))
+            index = integer(1), error = integer(1))
         if (result$error > 0) 
             stop("ERROR: Wrong input in pedigrees.")
         index <- result$index + 1
-        for (j in 1:nPersons_ped) {
+        for (j in 1:nPersonsPed) {
             if (i$findex[j] > 0) {
                 result <- .C("AddRelation", as.integer(neworder[i$findex[j]] - 
-                                                           1), as.integer(neworder[j] - 1), as.integer(index - 
-                                                                                                           1), error = integer(1))
+                  1), as.integer(neworder[j] - 1), as.integer(index - 
+                  1), error = integer(1))
                 if (result$error == 1) 
-                    stop("ERROR: Wrong input.")
+                  stop("ERROR: Wrong input.")
                 else if (result$error == 2) 
-                    stop("ERROR: Illegal relation based on Year-of-birth or is-Child data.")
+                  stop("ERROR: Illegal relation based on Year-of-birth or is-Child data.")
                 else if (result$error == 3) 
-                    stop("ERROR: Cycle in the pedigree or duplicate parent.")
+                  stop("ERROR: Cycle in the pedigree or duplicate parent.")
             }
             if (i$mindex[j] > 0) {
                 result <- .C("AddRelation", as.integer(neworder[i$mindex[j]] - 
-                                                           1), as.integer(neworder[j] - 1), as.integer(index - 
-                                                                                                           1), error = integer(1))
+                  1), as.integer(neworder[j] - 1), as.integer(index - 
+                  1), error = integer(1))
                 if (result$error == 1) 
-                    stop("ERROR: Wrong input.")
+                  stop("ERROR: Wrong input.")
                 else if (result$error == 2) 
-                    stop("ERROR: Illegal relation based on Year-of-birth or is-Child data.")
+                  stop("ERROR: Illegal relation based on Year-of-birth or is-Child data.")
                 else if (result$error == 3) 
-                    stop("ERROR: Cycle in the pedigree or duplicate parent.")
+                  stop("ERROR: Cycle in the pedigree or duplicate parent.")
             }
         }
     }
@@ -148,45 +148,45 @@ FamiliasPosterior <- function (pedigrees, loci, datamatrix, prior, ref = 1, kins
     for (i in loci) {
         if (any(i$alleles <= 0)) 
             stop(paste("ERROR: Problems with allele frequencies in locus", 
-                       i$locusname))
+                i$locusname))
         if (round(sum(i$alleles), 6) != 1) 
             stop(paste("ERROR: Allele frequencies must sum to 1 in locus", 
-                       i$locusname))
+                i$locusname))
         nAlleles <- length(i$alleles)
         if (!is.matrix(i$femaleMutationMatrix) | dim(i$femaleMutationMatrix)[1] != 
             nAlleles | dim(i$femaleMutationMatrix)[2] != nAlleles) 
             stop(paste("The female mutation matrix must be of a dimension corresponding to the vector of frequencies in locus", 
-                       i$locusname))
+                i$locusname))
         if (any(as.vector(i$femaleMutationMatrix) < 0)) 
             stop(paste("The female mutation matrix cannot have negative entries in locus", 
-                       i$locusname))
+                i$locusname))
         if (any(round(apply(i$femaleMutationMatrix, 1, sum), 
-                      6) != 1)) 
+            6) != 1)) 
             stop(paste("The rows in the female mutation matrix must sum to 1 in locus", 
-                       i$locusname))
+                i$locusname))
         if (!is.matrix(i$maleMutationMatrix) | dim(i$maleMutationMatrix)[1] != 
             nAlleles | dim(i$maleMutationMatrix)[2] != nAlleles) 
             stop(paste("The male mutation matrix must be of a dimension corresponding to the vector of frequencies in locus", 
-                       i$locusname))
+                i$locusname))
         if (any(as.vector(i$maleMutationMatrix) < 0)) 
             stop(paste("The male mutation matrix cannot have negative entries in locus", 
-                       i$locusname))
+                i$locusname))
         if (any(round(apply(i$maleMutationMatrix, 1, sum), 6) != 
-                1)) 
+            1)) 
             stop(paste("The rows in the male mutation matrix must sum to 1 in locus", 
-                       i$locusname))
+                i$locusname))
         lOfArrays <- nAlleles * nAlleles
         simplifyMatrix <- i$simpleMutationMatrices | simplifyMutations
         hasSilentAllele <- (names(i$alleles)[nAlleles] == "silent" | 
-                                names(i$alleles)[nAlleles] == "Silent")
+            names(i$alleles)[nAlleles] == "Silent")
         result <- .C("AddAlleleSystem", as.integer(nAlleles), 
-                     as.integer(lOfArrays), as.double(i$femaleMutationMatrix), 
-                     as.double(i$maleMutationMatrix), as.integer(simplifyMatrix), 
-                     as.integer(nAlleles), as.double(i$alleles), as.integer(hasSilentAllele), 
-                     index = integer(1), error = integer(1))
+            as.integer(lOfArrays), as.double(i$femaleMutationMatrix), 
+            as.double(i$maleMutationMatrix), as.integer(simplifyMatrix), 
+            as.integer(nAlleles), as.double(i$alleles), as.integer(hasSilentAllele), 
+            index = integer(1), error = integer(1))
         if (result$error > 0) 
             stop(paste("ERROR: Problems with input of allele system.", 
-                       i$locusname))
+                i$locusname))
     }
     if (dim(datamatrix)[2] != 2 * nloci) 
         stop("The datamatrix must have two columns for each locus.")
@@ -196,31 +196,31 @@ FamiliasPosterior <- function (pedigrees, loci, datamatrix, prior, ref = 1, kins
             A2 <- datamatrix[j, 2 * i]
             if (!(is.na(A1) && is.na(A2))) {
                 if (is.na(A1)) 
-                    A1 <- A2
+                  A1 <- A2
                 if (is.na(A2)) 
-                    A2 <- A1
+                  A2 <- A1
                 M1 <- match(A1, names(loci[[i]]$alleles), nomatch = 0)
                 if (M1 == 0) 
-                    stop(paste("Allele", A1, "is not found in locus", 
-                               loci[[i]]$locusname))
+                  stop(paste("Allele", A1, "is not found in locus", 
+                    loci[[i]]$locusname))
                 M2 <- match(A2, names(loci[[i]]$alleles), nomatch = 0)
                 if (M2 == 0) 
-                    stop(paste("Allele", A2, "is not found in locus", 
-                               loci[[i]]$locusname))
+                  stop(paste("Allele", A2, "is not found in locus", 
+                    loci[[i]]$locusname))
                 result <- .C("AddDNAObservation", as.integer(j - 
-                                                                 1), as.integer(i - 1), as.integer(M1 - 1), 
-                             as.integer(M2 - 1), error = integer(1))
+                  1), as.integer(i - 1), as.integer(M1 - 1), 
+                  as.integer(M2 - 1), error = integer(1))
                 if (result$error > 0) 
-                    stop("ERROR: Problems with input of marker data.")
+                  stop("ERROR: Problems with input of marker data.")
             }
         }
     }
     if (kinship < 0) 
         stop("ERROR: Kinship cannot be negative.")
     result <- .C("GetProbabilities", as.double(1), as.integer(-1), 
-                 as.double(1), as.double(1), as.integer(TRUE), as.double(kinship), 
-                 redundant = integer(npeds), probabilities = double(npeds), 
-                 likelihoods = double(nloci * npeds), error = integer(1))
+        as.double(1), as.double(1), as.integer(TRUE), as.double(kinship), 
+        redundant = integer(npeds), probabilities = double(npeds), 
+        likelihoods = double(nloci * npeds), error = integer(1))
     if (result$error == 1) 
         stop("ERROR: Problems computing probabilities.")
     if (result$error == 2) 
@@ -228,16 +228,16 @@ FamiliasPosterior <- function (pedigrees, loci, datamatrix, prior, ref = 1, kins
     pedigreeDuplicated <- as.logical(result$redundant)
     if (any(pedigreeDuplicated)) 
         stop(paste("ERROR: Some of the listed pedigrees were equivalent. Duplicated pedigrees are numbers", 
-                   (1:npeds)[pedigreeDuplicated]))
+            (1:npeds)[pedigreeDuplicated]))
     #prior <- result$probabilities
     likelihoodsPerSystem <- matrix(result$likelihoods, nloci, 
-                                   npeds)
+        npeds)
     likelihoods <- apply(likelihoodsPerSystem, 2, prod)
     posterior <- prior * likelihoods
     posterior <- posterior/sum(posterior)
     LR <- likelihoods/likelihoods[ref]
     LRperMarker <- likelihoodsPerSystem/likelihoodsPerSystem[, 
-                                                             ref]
+        ref]
     .C("NewFamilias")
     names(posterior) <- names(pedigrees)
     names(prior) <- names(pedigrees)
@@ -250,5 +250,5 @@ FamiliasPosterior <- function (pedigrees, loci, datamatrix, prior, ref = 1, kins
     colnames(likelihoodsPerSystem) <- names(pedigrees)
     rownames(likelihoodsPerSystem) <- locusnames
     list(posterior = posterior, prior = prior, LR = LR, LRperMarker = LRperMarker, 
-         likelihoods = likelihoods, likelihoodsPerSystem = likelihoodsPerSystem)
+        likelihoods = likelihoods, likelihoodsPerSystem = likelihoodsPerSystem)
 }

--- a/R/FamiliasPosterior.R
+++ b/R/FamiliasPosterior.R
@@ -56,12 +56,13 @@ FamiliasPosterior <- function (pedigrees, loci, datamatrix, prior, ref = 1, kins
                 i))
         }
             
-        if ((i > 1) && (j<=npersDatamatrixOriginal)) {
-            firstObseredInPed <- 1
-            while(pedPersonIndicesByDmPersonIndex[j,firstObseredInPed]==0) firstObseredInPed <- firstObseredInPed + 1
+        if (i > 1) {
+            firstObservedInPed <- 1
+            while(pedPersonIndicesByDmPersonIndex[j,firstObservedInPed]==0) firstObservedInPed <- firstObservedInPed + 1
             
-            if (pedigrees[[i]]$sex[pedPersonIndicesByDmPersonIndex[j, i]] != 
-                pedigrees[[firstObseredInPed]]$sex[pedPersonIndicesByDmPersonIndex[j, firstObseredInPed]]) 
+            if ((pedigrees[[i]]$sex[pedPersonIndicesByDmPersonIndex[j, i]] > 0) &&
+                (pedigrees[[i]]$sex[pedPersonIndicesByDmPersonIndex[j, i]] != 
+                pedigrees[[firstObservedInPed]]$sex[pedPersonIndicesByDmPersonIndex[j, firstObservedInPed]])) 
                 stop("Persons common to all pedigrees must have the same sex in all pedigrees!")
         }
     }

--- a/man/FamiliasPosterior.Rd
+++ b/man/FamiliasPosterior.Rd
@@ -133,4 +133,73 @@ locus1 <- FamiliasLocus(c(0.1, 0.2, 0.3, 0.4), c("A", "B", "C", "D"), "locus1",
 datamatrix <- data.frame(locus1.1 = c("A", "A", "C"), locus1.2 = c("B", "A", "C"))
 rownames(datamatrix) <- persons
 result <- FamiliasPosterior(mypedigrees, locus1, datamatrix)
+
+#Example 4: Adding an untyped ancestor affects the likelihood
+#when subpopulation correction is used even if the mutation matrix is stationary
+
+# ped1 is son by himself
+ped1 <- FamiliasPedigree(id="son", 
+                         dadid = c(NA), 
+                         momid = c(NA), 
+                         sex="male")
+
+# ped2 describes son with parents
+persons <- c("son", "mother", "AF")
+sex <- c("male", "female", "male")
+ped2 <- FamiliasPedigree(id=persons, 
+                         dadid = c("AF", NA, NA), 
+                         momid = c("mother", NA, NA), 
+                         sex=sex)
+
+# only the son is typed
+datamatrix <- matrix(c("A","A"), ncol=2)
+rownames(datamatrix) <- "son"
+
+f <- setNames(c(0.3, 0.7), c("A", "B"))
+
+locus1 <- FamiliasLocus(f, 
+                        MutationModel = "Proportional", 
+                        MutationRate = 1e-2)
+
+# if Fst=0, then ped1 and ped2 are equivalent
+pr_ped1_HW <- FamiliasPosterior(list(ped1), locus1, datamatrix)$likelihoods
+pr_ped2_HW <- FamiliasPosterior(list(ped2), locus1, datamatrix)$likelihoods
+
+# verify calculations by hand
+stopifnot(all.equal(pr_ped1_HW, pr_ped2_HW))
+stopifnot(all.equal(pr_ped1_HW, as.numeric(f["A"]^2)))
+stopifnot(all.equal(pr_ped2_HW, as.numeric(f["A"]^2)))
+
+# if Fst>0, then ped1 and ped2 are not equivalent
+Fst <- 0.03
+
+pr_ped1_Fst <- FamiliasPosterior(list(ped1), locus1, datamatrix, kinship = Fst)$likelihoods
+pr_ped2_Fst <- FamiliasPosterior(list(ped2), locus1, datamatrix, kinship = Fst)$likelihoods
+
+# pr_ped1_Fst and pr_ped2_Fst should not be equal: stop if equal
+stopifnot(!isTRUE(all.equal(pr_ped1_Fst, pr_ped2_Fst)))
+
+# compute pr_ped1_Fst by hand to verify the result
+pr_ped1_Fst_manual <- as.numeric(f["A"]*Fst + f["A"]^2 * (1-Fst))
+stopifnot(all.equal(pr_ped1_Fst, pr_ped1_Fst_manual))
+
+# compute pr_ped2_Fst by hand to verify the result
+# computing Pr(son=A,A|ped2) with subpopulation correction and mutations
+# requires an explicit sum over the two parental alleles
+
+pr_AA <- as.numeric(f["A"]*Fst + f["A"]^2 * (1-Fst))
+pr_AB <- 2 * as.numeric(f["A"]*f["B"] * (1-Fst))
+pr_BB <- as.numeric(f["B"]*Fst + f["B"]^2 * (1-Fst))
+
+M <- locus1$maleMutationMatrix
+
+pr_AA_given_AA <- M["A","A"]^2
+pr_AA_given_AB <- M["A","A"] * M["B","A"]
+pr_AA_given_BB <- M["B","A"]^2
+
+pr_ped2_Fst_manual <- pr_AA*pr_AA_given_AA +pr_AB*pr_AA_given_AB + pr_BB*pr_AA_given_BB
+
+stopifnot(all.equal(pr_ped2_Fst, pr_ped2_Fst_manual))
+
+
 }


### PR DESCRIPTION
These changes intend to work around issue https://github.com/thoree/Familias/issues/3. If Fst>0, then untyped pedigree members are added to the `datamatrix` explicitly. 

Some further changes were needed because it is no longer guaranteed that every person in the `datamatrix` is present in every pedigree. I have added a check that every person in the `datamatrix` with at least one locus typed needs to be present in every pedigree and hope this does not cause any regressions.