### PR TITLE
Fix C++20 compilation errors for CRAN compatibility

### DIFF
--- a/src/GroupOfPersons.cpp
+++ b/src/GroupOfPersons.cpp
@@ -1,6 +1,8 @@
 /* $Id: GroupOfPersons.C,v 1.10 2000/08/07 07:44:07 mostad Exp $ */
 
 #include <cstdio>
+#include <cstring>
+#include <string>
 
 #include "special.h"
 #include "GroupOfPersons.h"
@@ -56,22 +58,31 @@ void GroupOfPersons::readData(ifstream& is)
    namesWomen = new char*[nWomen]; 
    for (i=0; i<nWomen; i++)
    {
-      namesWomen[i] = new char[100]; 
-      is>>namesWomen[i];    
+      namesWomen[i] = new char[100];
+      std::string temp;
+      is >> temp;
+      strncpy(namesWomen[i], temp.c_str(), 99);
+      namesWomen[i][99] = '\0';
    }
    is>>nMen; 
    namesMen = new char*[nMen]; 
    for (i=0; i<nMen; i++)
    {
-      namesMen[i] = new char[100]; 
-      is>>namesMen[i]; 
+      namesMen[i] = new char[100];
+      std::string temp;
+      is >> temp;
+      strncpy(namesMen[i], temp.c_str(), 99);
+      namesMen[i][99] = '\0';
    }
    is>>nChildren; 
    namesChildren = new char*[nChildren]; 
    for (i=0; i<nChildren; i++)
    {
-      namesChildren[i] = new char[100]; 
-      is>>namesChildren[i]; 
+      namesChildren[i] = new char[100];
+      std::string temp;
+      is >> temp;
+      strncpy(namesChildren[i], temp.c_str(), 99);
+      namesChildren[i][99] = '\0';
    }
    is>>nExtraWomen; 
    is>>nExtraMen; 

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -2,7 +2,8 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <sstream> 
+#include <sstream>
+#include <string> 
 
 #include "special.h"
 #include "table.h"
@@ -50,17 +51,12 @@ char* my_place_in_string(double d) {
     //	ost<<d;
     //	ost<<'X';
     //}
-    stringstream ss (stringstream::in | stringstream::out); 
-    ss << d; 
-    ss >> result; 
-    int length = 0;
-
-
-    //    while (result[length]!='X') length++;
-    length = 15; 
-
-
-    result[length] = '\0';
+    stringstream ss (stringstream::in | stringstream::out);
+    ss << d;
+    std::string temp;
+    ss >> temp;
+    strncpy(result, temp.c_str(), 15);
+    result[15] = '\0';
     return result;
 }
 


### PR DESCRIPTION
In C++20, operator>>(istream&, char*) was removed from the standard library for security reasons (no way to know the destination buffer size, risk of buffer overflow). This caused compilation failures with gcc 15 and other compilers using C++20 or later.

The fix uses std::string as a temporary buffer and strncpy to safely copy to the existing char* arrays:

- src/GroupOfPersons.cpp: Modified 3 reading loops (namesWomen, namesMen, namesChildren) to read into std::string first, then copy with strncpy ensuring null-termination.

- src/table.cpp: Modified my_place_in_string() function to use std::string as intermediate buffer.

This solution maintains backward compatibility with C++11/14/17
