### PR TITLE
CRAN release v2.6.4: fix C++20 compilation errors

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,4 +10,5 @@ README_cache
 ^revdep$
 ^notes$
 ^.github$
+^\.[a-z]
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: Familias
 Title: Probabilities for Pedigrees Given DNA Data
-Version: 2.6.3
+Version: 2.6.4
 Authors@R: c(
     person(given = "Petter",
            family = "Mostad",
@@ -9,7 +9,7 @@ Authors@R: c(
            email = "mostad@chalmers.se"),
     person(given = "Thore",
            family = "Egeland",
-           role = c("aut", "cre"),
+           role = "aut",
            email = "Thore.Egeland@nmbu.no"),
     person(given = "Franco",
            family = "Marsico",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Familias 2.6.4
+
+* Fixed C++20 compilation errors with gcc 15 and clang 21 (stream extraction into char* removed in C++20)
+
 # Familias 2.6.3
 
 * Fixed c code problem with gcc15


### PR DESCRIPTION
## Summary

- Bump version to 2.6.4 for CRAN resubmission
- Set Franco Marsico as sole maintainer (`cre`) to fix the dual-maintainer error that prevented `R CMD build`
- Exclude hidden directories from package build via `.Rbuildignore`
- Update `NEWS.md` with description of the C++20 fix

## Context

CRAN has scheduled Familias for archival on 2026-02-20 due to compilation failures with gcc 15 / clang 21 under C++20. The C++ fix (replacing `operator>>` into `char*` with `std::string` intermediaries) was already applied in v2.6.3 (commit 439efd6) but was never successfully submitted to CRAN.

This PR prepares v2.6.4 for CRAN submission. `R CMD check --as-cran` passes with only the expected "New maintainer" NOTE.

## Test plan

- [x] `R CMD build` succeeds
- [x] `R CMD check --as-cran` passes (2 NOTEs: new maintainer + time verification)
- [ ] Submit to CRAN via `devtools::submit_cran()`